### PR TITLE
[Add] reset.css common.css frontページの作成

### DIFF
--- a/vueproject/src/App.vue
+++ b/vueproject/src/App.vue
@@ -1,7 +1,5 @@
 <template>
-  <div id="app">
     <router-view/>
-  </div>
 </template>
 
 <script>

--- a/vueproject/src/assets/style/common.css
+++ b/vueproject/src/assets/style/common.css
@@ -1,0 +1,5 @@
+.wrapper{
+    max-width: 480px;
+    text-align: center;
+    margin: 0 auto;
+}

--- a/vueproject/src/assets/style/reset.css
+++ b/vueproject/src/assets/style/reset.css
@@ -1,0 +1,99 @@
+/***
+    The new CSS reset - version 1.8.4 (last updated 14.2.2023)
+    GitHub page: https://github.com/elad2412/the-new-css-reset
+***/
+
+/*
+    Remove all the styles of the "User-Agent-Stylesheet", except for the 'display' property
+    - The "symbol *" part is to solve Firefox SVG sprite bug
+ */
+ *:where(:not(html, iframe, canvas, img, svg, video, audio):not(svg *, symbol *)) {
+    all: unset;
+    display: revert;
+}
+
+/* Preferred box-sizing value */
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+/* Reapply the pointer cursor for anchor tags */
+a, button {
+    cursor: revert;
+}
+
+/* Remove list styles (bullets/numbers) */
+ol, ul, menu {
+    list-style: none;
+}
+
+/* For images to not be able to exceed their container */
+img {
+    max-inline-size: 100%;
+    max-block-size: 100%;
+}
+
+/* removes spacing between cells in tables */
+table {
+    border-collapse: collapse;
+}
+
+/* Safari - solving issue when using user-select:none on the <body> text input doesn't working */
+input, textarea {
+    -webkit-user-select: auto;
+}
+
+/* revert the 'white-space' property for textarea elements on Safari */
+textarea {
+    white-space: revert;
+}
+
+/* minimum style to allow to style meter element */
+meter {
+    -webkit-appearance: revert;
+    appearance: revert;
+}
+
+/* preformatted text - use only for this feature */
+:where(pre) {
+    all: revert;
+}
+
+/* reset default text opacity of input placeholder */
+::placeholder {
+    color: unset;
+}
+
+/* remove default dot (•) sign */
+::marker {
+    content: initial;
+}
+
+/* fix the feature of 'hidden' attribute.
+   display:revert; revert to element instead of attribute */
+:where([hidden]) {
+    display: none;
+}
+
+/* revert for bug in Chromium browsers
+   - fix for the content editable attribute will work properly.
+   - webkit-user-select: auto; added for Safari in case of using user-select:none on wrapper element*/
+:where([contenteditable]:not([contenteditable="false"])) {
+    -moz-user-modify: read-write;
+    -webkit-user-modify: read-write;
+    overflow-wrap: break-word;
+    -webkit-line-break: after-white-space;
+    -webkit-user-select: auto;
+}
+
+/* apply back the draggable feature - exist only in Chromium and Safari */
+:where([draggable="true"]) {
+    -webkit-user-drag: element;
+}
+
+/* Revert Modal native behavior */
+:where(dialog:modal) {
+    all: revert;
+}

--- a/vueproject/src/components/pages/FrontPage.vue
+++ b/vueproject/src/components/pages/FrontPage.vue
@@ -1,7 +1,13 @@
 <template>
-  <div>
-    <p>test</p>
-    <p>この文字が表示されれば</p>
+  <div class="wrapper">
+    <div class="builderーarea">
+      <input class="room_search rounded bg-secondary text-light py-1" type="text" placeholder="部屋を探す">
+      <input class="room_build rounded-pill bg-dark text-light py-1" type="text" value="部屋を作る">
+    </div>
+    <div class="builderーarea">
+      <input class="login rounded-pill text-dark py-1" type="text" value="ログイン">
+      <input class="create_account rounded-pill bg-dark text-light py-1" type="text" value="アカウントを作る">
+    </div>
   </div>
 </template>
 
@@ -15,4 +21,41 @@ export default {
 
 <!-- アプリホーム画面 -->
 <style scoped>
+.wrapper .builderーarea {
+  margin-top: 60px;
+}
+
+.wrapper .builderーarea input{
+  display: block;
+  margin: 0 auto;
+  text-align: center;
+  font-size: 16px;
+}
+
+.wrapper .builderーarea .room_build,
+.wrapper .builderーarea .room_search{
+  width: 330px;
+}
+
+.wrapper .builderーarea .room_search{
+  opacity: 0.5;
+}
+
+.wrapper .builderーarea .login,
+.wrapper .builderーarea .create_account{
+  width: 180px;
+}
+
+.wrapper .builderーarea .login{
+  border: 1px solid #000;
+}
+
+.wrapper .builderーarea .create_account{
+
+}
+
+/* ボタン下にmarginをかける */
+.wrapper .builderーarea input:nth-child(1){
+  margin-bottom: 10px;
+}
 </style>

--- a/vueproject/src/main.js
+++ b/vueproject/src/main.js
@@ -1,6 +1,8 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
+import './assets/style/common.css';
+import './assets/style/reset.css';
 import 'bootstrap/dist/css/bootstrap.css'
 import 'bootstrap-vue/dist/bootstrap-vue.css'
 


### PR DESCRIPTION
[問題]
・共通のcssが作成されていない
・デフォルトのcssを削除するreset.cssが設定されていない
・frontページのレイアウトの作成

[技術的にどう改善したか]
・共通cssをassets/style/common.cssを作成しました
・reset.cssの導入　以下のurlのcssを参考にしました
https://github.com/elad2412/the-new-css-reset/blob/main/css/reset.css
・figmaのデザインをもとに作成しました。

[動作確認]
動作確認しています。


[修正箇所のスクショ] 
![image](https://github.com/https-github-com-YuSa0-6/Vue.js-dev/assets/102906375/726011ac-e517-429e-92dd-3f2e33f429f5)
