### PR TITLE
遷移の際のスクロール位置の変更

### DIFF
--- a/vueproject/src/router/index.js
+++ b/vueproject/src/router/index.js
@@ -12,11 +12,16 @@ const routes = [
 const router = createRouter({
   history: createWebHistory(),
   routes,
-  scrollBehavior(to, from, savedPosition) {
-    return {
-      top: 0
+ scrollBehavior(to, from, savedPosition){
+    if (savedPosition) {
+      return savedPosition
+    } else { 
+      return {
+        top: 0
+      }
     }
-  },
+  }
+
 })
 
 export default router

--- a/vueproject/src/router/index.js
+++ b/vueproject/src/router/index.js
@@ -10,8 +10,13 @@ const routes = [
 ]
 
 const router = createRouter({
-    history: createWebHistory(),
-    routes,
+  history: createWebHistory(),
+  routes,
+  scrollBehavior(to, from, savedPosition) {
+    return {
+      top: 0
+    }
+  },
 })
 
 export default router


### PR DESCRIPTION
[問題]
遷移の際のスクロール位置が保持される

[技術的にどう改善したか]
index.jsのconst router = createRouterに 
scrollBehavior(to, from, savedPosition) {
    return {
      top: 0
    }
  },
を追加した
[動作確認]
動作確認しています。