### PR TITLE
ゲームランキング画面の実装

### DIFF
--- a/vueproject/src/components/modules/SpeechBubble.vue
+++ b/vueproject/src/components/modules/SpeechBubble.vue
@@ -1,57 +1,51 @@
 <template>
-    <div class="authoerWrapper">
-        <div>
-            <img :src="getImagePath" alt="人生の作者">
-            <p>{{user_name}}</p>
-        </div>
-        <p class="authoerTitle">{{life_name}}</p>
+  <div class="authoerWrapper">
+    <div>
+      <img :src="getImagePath" alt="人生の作者" />
+      <p>{{ user_name }}</p>
     </div>
+    <p class="authoerTitle">{{ life_name }}</p>
+  </div>
 </template>
 
 <script>
 export default {
-    name: 'SpeechBubble',
-    props: {
-        img_pass : {
-            type: String,
-            required: true
-        },
-        user_name : {
-            type: String,
-            required: false
-        },
-        life_name : {
-            type: String,
-            required: false
-        },
+  name: "SpeechBubble",
+  props: {},
+  data() {
+    return {
+      img_pass: "user_noImage.svg",
+      user_name: "test",
+      life_name: "山田の人生",
+    };
+  },
+  computed: {
+    getImagePath() {
+      return require("@/assets/image/" + this.img_pass);
     },
-    computed: {
-        getImagePath() {
-            return require('@/assets/image/' + this.img_pass);
-        }
-    }
-}
+  },
+};
 </script>
 
 <!-- 作成したゲーム(作製未も含む)を表示するためのモジュール -->
 <style scoped>
-.authoerWrapper{
-    display: flex;
-    justify-content: space-between;
-    padding: 10px 20px 0 20px;
+.authoerWrapper {
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 20px 0 20px;
 }
-.authoerWrapper img{
-    max-width: 40px;
+.authoerWrapper img {
+  max-width: 40px;
 }
-.authoerTitle{
-    color: #6C7072;
-    font-weight: bold;
-    background: #F2F4F5;
-    width: 250px;
-    height: 40px;
-    line-height: 40px;
-    text-align: left;
-    padding-left: 10px;
-    border-radius: 10px;
+.authoerTitle {
+  color: #6c7072;
+  font-weight: bold;
+  background: #f2f4f5;
+  width: 250px;
+  height: 40px;
+  line-height: 40px;
+  text-align: left;
+  padding-left: 10px;
+  border-radius: 10px;
 }
 </style>

--- a/vueproject/src/components/pages/GameDisplay.vue
+++ b/vueproject/src/components/pages/GameDisplay.vue
@@ -131,7 +131,6 @@ export default {
       gameOver: false,
 
       // ローカルストレージようの配列
-
     };
   },
   props: {},
@@ -141,6 +140,7 @@ export default {
   },
   methods: {
     rollDice() {
+      // this.modalToggle()
       // ゲーム終了していたら処理しない
       if (this.gameOver) {
         return;
@@ -160,17 +160,17 @@ export default {
       this.userArray[this.currentUserIndex].push(diceValue);
 
       if (this.remainingSquares[this.currentUserIndex] <= 0) {
-      this.finishOrder.push({
-        name: this.userName[this.currentUserIndex],
-        diceValues: this.currentUserIndex
-      });
-    }
+        this.finishOrder.push({
+          name: this.userName[this.currentUserIndex],
+          diceValues: this.currentUserIndex,
+        });
+      }
 
       // ユーザーを次に人に変更
       this.currentUserIndex = (this.currentUserIndex + 1) % 4;
 
       // this.openModal(diceValue); <- testのためコメントアウト
-      this.PlayersFinishedCheck()
+      this.PlayersFinishedCheck();
     },
     modalToggle() {
       this.isActive = !this.isActive;
@@ -183,11 +183,15 @@ export default {
       if (allPlayersFinished) {
         // 全プレイヤーがゴールしていたらゲームを終了する
         this.gameOver = true;
+        // localstrageに追加
+        localStorage.setItem("finishOrder", JSON.stringify(this.finishOrder));
 
-        localStorage.setItem('finishOrder', JSON.stringify(this.finishOrder));
+        alert("お前ら終わったんや!2秒後に終了画面に遷移します");
 
-alert(this.finishOrder)
-        alert("お前ら終わったんや!5秒後に終了画面に遷移します");
+        // 画面遷移
+        setTimeout(() => {
+          document.location = "GameRanking.vue"
+        }, 2000);
         return;
       }
     },

--- a/vueproject/src/components/pages/GameDisplay.vue
+++ b/vueproject/src/components/pages/GameDisplay.vue
@@ -76,6 +76,7 @@ export default {
       life_name: "山田の人生",
       userArray: [[], [], [], []],
       currentUserIndex: 0,
+      finishOrder: [],
       assocArray: {
         1: [60, 0],
         2: [120, 0],
@@ -128,6 +129,9 @@ export default {
       isModalOpen: false,
       userName: ["dog", "cat", "pig", "sheep"],
       gameOver: false,
+
+      // ローカルストレージようの配列
+
     };
   },
   props: {},
@@ -137,14 +141,15 @@ export default {
   },
   methods: {
     rollDice() {
-      // this.modalToggle()
       // ゲーム終了していたら処理しない
       if (this.gameOver) {
         return;
       }
+
       // ゴールしたユーザーを飛ばす処理
       if (this.remainingSquares[this.currentUserIndex] <= 0) {
         do {
+          // ローカルストレージで保存する
           this.currentUserIndex = (this.currentUserIndex + 1) % 4;
         } while (this.remainingSquares[this.currentUserIndex] <= 0);
       }
@@ -153,10 +158,19 @@ export default {
       let diceValue = Math.floor(Math.random() * 6) + 1;
       // 各ユーザーの進んだマスの数を保存
       this.userArray[this.currentUserIndex].push(diceValue);
+
+      if (this.remainingSquares[this.currentUserIndex] <= 0) {
+      this.finishOrder.push({
+        name: this.userName[this.currentUserIndex],
+        diceValues: this.currentUserIndex
+      });
+    }
+
       // ユーザーを次に人に変更
       this.currentUserIndex = (this.currentUserIndex + 1) % 4;
-      this.openModal(diceValue);
-      setTimeout(this.PlayersFinishedCheck(), 200);
+
+      // this.openModal(diceValue); <- testのためコメントアウト
+      this.PlayersFinishedCheck()
     },
     modalToggle() {
       this.isActive = !this.isActive;
@@ -169,6 +183,10 @@ export default {
       if (allPlayersFinished) {
         // 全プレイヤーがゴールしていたらゲームを終了する
         this.gameOver = true;
+
+        localStorage.setItem('finishOrder', JSON.stringify(this.finishOrder));
+
+alert(this.finishOrder)
         alert("お前ら終わったんや!5秒後に終了画面に遷移します");
         return;
       }

--- a/vueproject/src/components/pages/GameDisplay.vue
+++ b/vueproject/src/components/pages/GameDisplay.vue
@@ -1,10 +1,6 @@
 <template>
   <div class="wrapper">
-    <SpeechBubble
-      :img_pass="img_pass"
-      :user_name="user_name"
-      :life_name="life_name"
-    />
+    <SpeechBubble/>
     <div class="gameTurn">
       <!-- スコア -->
       <div>
@@ -64,16 +60,13 @@
 
 <script>
 import SpeechBubble from "@/components/modules/SpeechBubble";
-import FooterNav from "../modules/FooterNav.vue";
+import FooterNav from "../modules/FooterNav";
 
 export default {
   name: "GameDisplay",
   data() {
     return {
       isActive: true,
-      img_pass: "user_noImage.svg",
-      user_name: "test",
-      life_name: "山田の人生",
       userArray: [[], [], [], []],
       currentUserIndex: 0,
       finishOrder: [],
@@ -162,7 +155,7 @@ export default {
       if (this.remainingSquares[this.currentUserIndex] <= 0) {
         this.finishOrder.push({
           name: this.userName[this.currentUserIndex],
-          diceValues: this.currentUserIndex,
+          userImages: this.userImages[this.currentUserIndex],
         });
       }
 

--- a/vueproject/src/components/pages/GameRanking.vue
+++ b/vueproject/src/components/pages/GameRanking.vue
@@ -1,19 +1,48 @@
 <template>
   <div class="background-wrapper wrapper">
+    <SpeechBubble />
+    <div>
+      <div>スコアランキング</div>
+      <div v-for="(finishUser, index) in finishOrder" :key="finishUser.name">
+        <p>{{ index + 1 }}</p>
+        <div>
+          <img :src="finishUser.userImages" alt="ユーザー写真" />
+          <p>{{ finishUser.name }}</p>
+        </div>
+      </div>
+    </div>
     <FooterNav />
   </div>
 </template>
 
 <script>
-import FooterNav from '../modules/FooterNav.vue';
+import FooterNav from "../modules/FooterNav";
+import SpeechBubble from "../modules/SpeechBubble";
 
 export default {
-    name: "GameRanking",
-    props: {},
-    components: { FooterNav }
-}
+  name: "GameRanking",
+  props: {},
+  data() {
+    return {
+      finishOrder: [],
+    };
+  },
+  components: {
+    SpeechBubble,
+    FooterNav,
+  },
+  created() {
+    const storedFinishOrder = JSON.parse(localStorage.getItem("finishOrder"));
+    if (storedFinishOrder) {
+      this.finishOrder = storedFinishOrder;
+    }
+  },
+};
 </script>
 
 <!-- ランキング画面 -->
 <style scoped>
+.finishUserWrapper{
+  display: flex;
+}
 </style>


### PR DESCRIPTION
[問題]
・利用する人生のコンポーネント化が不十分
・ゲーム完了時の順位の取得ができていない
・画面遷移を動的に行えていない

[技術的にどう改善したか]
・利用する人生のコンポーネントを分割し、2つのページで呼び出しできるように変更した。
・localstrageに値が格納されるように、サイコロが回ったタイミングで値取得の判定を行った。最終的にはゲームを全て完了したタイミングでlocalstrageへの保存を行なった。
・localstrageは現時点ではユーザ名と画像のみを取得。追加でメールアドレスを格納しても良い
・ゲーム完了後の2秒ごに遷移するように非同期処理を追加
・localstrageの受け取りおよび表示の処理を実装

![image](https://github.com/Team2-developers/Vue.js-dev/assets/102906375/dfe62fab-1133-4c49-b706-5d31107ac1c2)
